### PR TITLE
update dependencies

### DIFF
--- a/ghga_datasteward_kit/__init__.py
+++ b/ghga_datasteward_kit/__init__.py
@@ -15,4 +15,4 @@
 
 """A utils package for GHGA data stewards."""
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/ghga_datasteward_kit/catalog_accession_generator.py
+++ b/ghga_datasteward_kit/catalog_accession_generator.py
@@ -20,7 +20,7 @@
 
 from pathlib import Path
 
-from metldata.accession_registry.accession_handler import AccessionHandler
+from metldata.accession_registry.accession_registry import AccessionRegistry
 from metldata.accession_registry.accession_store import AccessionStore
 from metldata.accession_registry.config import Config
 
@@ -45,21 +45,21 @@ SUFFIX_LENGTH = 14
 
 
 def generate_accessions(
-    *, resource_type: str, number: int, accession_handler: AccessionHandler
+    *, resource_type: str, number: int, accession_registry: AccessionRegistry
 ) -> list[str]:
     """Generate Accessions to be used in the Metadata Catalog.
 
     Args:
         resource_type (str): The resource type for which to generate accessions.
         number (int): The number of accessions to generate.
-        accession_handler (AccessionHandler): The accession handler to use.
+        accession_registry (AccessionRegistry): The accession registry to use.
 
     Returns:
         list[str]: The generated accessions.
     """
 
     accessions = [
-        accession_handler.get_accession(resource_type=resource_type)
+        accession_registry.get_accession(resource_type=resource_type)
         for _ in range(number)
     ]
     return accessions
@@ -100,10 +100,12 @@ def main(*, store_path: Path, resource_type: str, number: int) -> list[str]:
 
     config = get_config(store_path=store_path)
     accession_store = AccessionStore(config=config)
-    accession_handler = AccessionHandler(config=config, accession_store=accession_store)
+    accession_registry = AccessionRegistry(
+        config=config, accession_store=accession_store
+    )
 
     return generate_accessions(
         resource_type=resource_type,
         number=number,
-        accession_handler=accession_handler,
+        accession_registry=accession_registry,
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,10 +35,11 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
-    hexkit[mongodb,s3]==0.9.2
+    hexkit[mongodb,s3]==0.10.0
     httpx==0.23.3
-    ghga-connector==0.2.12
-    metldata==0.1.0
+    ghga-connector==0.3.2
+    ghga-service-chassis-lib==0.17.7
+    metldata==0.2.1
 
 python_requires = >= 3.9
 


### PR DESCRIPTION
hexkit and metldata versions are updated. These changes required an update of ghga-connector version also. Since the latest version of ghga-connector lack of ghga-service-chassis-lib, which is used by tests, it is also added as a dependency. 

Also because of metldata update, AccessionHandler required to be renamed to AccessionRegistry. Check: https://github.com/ghga-de/metldata/compare/0.1.0...0.2.0