### PR TITLE
Re-add dev_launcher

### DIFF
--- a/.devcontainer/dev_launcher
+++ b/.devcontainer/dev_launcher
@@ -1,0 +1,5 @@
+#!/bin/bash
+# install service in dev container
+
+echo "This repository does not provide any service. Aborting." >&2
+exit 1

--- a/.mandatory_files_ignore
+++ b/.mandatory_files_ignore
@@ -1,7 +1,6 @@
 # Optional list of files which are actually mandatory in the template
 # but are allowed to be removed in the current repository
 scripts/script_utils/fastapi_app_location.py
-.devcontainer/dev_launcher
 config_schema.json
 .description.md
 .design.md


### PR DESCRIPTION
Currently the devcontainer cannot be built. Removing dev_launcher would also have required changing `Dockerfile`, which can be avoided by leaving a dummy script.