### PR TITLE
Fixes for subcommand typo and hardcoded ingest endpoints

### DIFF
--- a/ingest_config.md
+++ b/ingest_config.md
@@ -11,6 +11,10 @@
 
 - **`file_ingest_baseurl`** *(string)*: Base URL under which the /ingest endpoint is available. This is an endpoint exposed by GHGA Central. This value is provided by GHGA Central on demand.
 
+- **`file_ingest_federated_endpoint`** *(string)*: Path to the FIS endpoint (relative to baseurl) expecting the new style"+" upload metadata including a secret ID instead of the actual secret.
+
+- **`file_ingest_legacy_endpoint`** *(string)*: Path to the FIS endpoint (relative to baseurl) expecting the old style"+"upload metadata including the encryption secret.
+
 - **`file_ingest_pubkey`** *(string)*: Public key provided by GHGA Central used to encrypt the communication with GHGA Central.
 
 - **`input_dir`** *(string, format: path)*: Path to directory containing output files from the upload/batch_upload command.

--- a/src/ghga_datasteward_kit/batch_s3_upload.py
+++ b/src/ghga_datasteward_kit/batch_s3_upload.py
@@ -78,7 +78,7 @@ def prepare_upload_command_line(
     log_file_path = output_dir / f"{file.alias}.log"
     python_interpreter_path = Path(sys.executable)
 
-    subcommand = "legacy_upload" if legacy_mode else "upload"
+    subcommand = "legacy-upload" if legacy_mode else "upload"
 
     return (
         f"{python_interpreter_path} -m ghga_datasteward_kit files {subcommand}"

--- a/src/ghga_datasteward_kit/file_ingest.py
+++ b/src/ghga_datasteward_kit/file_ingest.py
@@ -31,27 +31,41 @@ class IngestConfig(SubmissionStoreConfig):
     """Config options for calling the file ingest endpoint"""
 
     file_ingest_baseurl: str = Field(
-        ...,
+        default=...,
         description=(
             "Base URL under which the /ingest endpoint is available."
             + " This is an endpoint exposed by GHGA Central. This value is provided by"
             + " GHGA Central on demand."
         ),
     )
+    file_ingest_federated_endpoint: str = Field(
+        default="/federated/ingest_metadata",
+        description=(
+            "Path to the FIS endpoint (relative to baseurl) expecting the new style"
+            + " upload metadata including a secret ID instead of the actual secret."
+        ),
+    )
+    file_ingest_legacy_endpoint: str = Field(
+        default="/legacy/ingest",
+        description=(
+            "Path to the FIS endpoint (relative to baseurl) expecting the old style"
+            + "upload metadata including the encryption secret."
+        ),
+    )
     file_ingest_pubkey: str = Field(
-        ...,
+        default=...,
         description=(
             "Public key provided by GHGA Central used to encrypt the communication with"
             + " GHGA Central."
         ),
     )
     input_dir: Path = Field(
-        ...,
+        default=...,
         description="Path to directory containing output files from the "
         + "upload/batch_upload command.",
     )
     map_files_fields: list[str] = Field(
-        ["study_files"],
+        default=["study_files"],
         description="Names of the accession map fields for looking up the"
         + " alias->accession mapping.",
     )
@@ -115,10 +129,10 @@ def file_ingest(
     """
     try:
         output_metadata = models.OutputMetadata.load(input_path=in_path)
-        endpoint = "/federated/ingest_metadata"
+        endpoint = config.file_ingest_federated_endpoint
     except (KeyError, ValidationError):
         output_metadata = models.LegacyOutputMetadata.load(input_path=in_path)
-        endpoint = "/legacy/ingest"
+        endpoint = config.file_ingest_legacy_endpoint
 
     endpoint_url = f"{config.file_ingest_baseurl}{endpoint}"
 

--- a/src/ghga_datasteward_kit/metadata.py
+++ b/src/ghga_datasteward_kit/metadata.py
@@ -53,11 +53,13 @@ class MetadataConfig(
     """Config parameters used for submission and transformation of metadata."""
 
     artifact_model_dir: Path = Field(
-        ..., description="Path to save the artifact models and artifact infos to."
+        default=...,
+        description="Path to save the artifact models and artifact infos to.",
     )
 
     workflow_config: GHGA_ARCHIVE_WORKFLOW.config_cls = Field(
-        ..., description="Configuration for the metadata transformation workflow."
+        default=...,
+        description="Configuration for the metadata transformation workflow.",
     )
 
 

--- a/src/ghga_datasteward_kit/s3_upload/config.py
+++ b/src/ghga_datasteward_kit/s3_upload/config.py
@@ -41,10 +41,10 @@ class LegacyConfig(BaseSettings):
     """Required options for legacy file uploads."""
 
     s3_endpoint_url: SecretStr = Field(
-        ..., description="URL of the local data hub's S3 server."
+        default=..., description="URL of the local data hub's S3 server."
     )
     s3_access_key_id: SecretStr = Field(
-        ...,
+        default=...,
         description=(
             "This parameter plus the s3_secret_access_key serve as credentials for"
             + " accessing the internal staging bucket (as in"
@@ -54,11 +54,11 @@ class LegacyConfig(BaseSettings):
         ),
     )
     s3_secret_access_key: SecretStr = Field(
-        ...,
+        default=...,
         description=("Secret access key corresponding to the `s3_access_key_id`."),
     )
     bucket_id: str = Field(
-        ...,
+        default=...,
         description=(
             "Bucket ID of the internal staging bucket of the local data hub's S3 system"
             "where the encrypted files are uploaded to."
@@ -68,7 +68,7 @@ class LegacyConfig(BaseSettings):
         default=16, description="Upload part size in MiB. Has to be between 5 and 5120."
     )
     output_dir: Path = Field(
-        ...,
+        default=...,
         description=(
             "Directory for the output metadata files. For each file upload one metadata"
             + " file in yaml format will be generated. It contains details on the files"
@@ -88,14 +88,14 @@ class Config(LegacyConfig):
     """Required options for file uploads."""
 
     secret_ingest_pubkey: str = Field(
-        ...,
+        default=...,
         description=(
             "Public key provided by GHGA Central used to encrypt the communication with"
             + " GHGA Central."
         ),
     )
     secret_ingest_baseurl: str = Field(
-        ...,
+        default=...,
         description=(
             "Base URL under which the /ingest_secret endpoint is available."
             + " This is an endpoint exposed by GHGA Central. This value is provided by"

--- a/tests/test_file_ingest.py
+++ b/tests/test_file_ingest.py
@@ -73,7 +73,7 @@ async def test_legacy_ingest_directly(
     httpx_mock: HTTPXMock,
 ):
     """Test file_ingest function directly"""
-    endpoint_url = f"{legacy_ingest_fixture.config.file_ingest_baseurl}/legacy/ingest"
+    endpoint_url = f"{legacy_ingest_fixture.config.file_ingest_baseurl}{legacy_ingest_fixture.config.file_ingest_legacy_endpoint}"
     token = generate_token()
 
     httpx_mock.add_response(
@@ -117,9 +117,7 @@ async def test_ingest_directly(
     httpx_mock: HTTPXMock,
 ):
     """Test file_ingest function directly"""
-    endpoint_url = (
-        f"{ingest_fixture.config.file_ingest_baseurl}/federated/ingest_metadata"
-    )
+    endpoint_url = f"{ingest_fixture.config.file_ingest_baseurl}{ingest_fixture.config.file_ingest_federated_endpoint}"
     token = generate_token()
 
     httpx_mock.add_response(url=endpoint_url, status_code=202)
@@ -162,7 +160,7 @@ async def test_legacy_main(
     httpx_mock: HTTPXMock,
 ):
     """Test if main file ingest function works correctly"""
-    endpoint_url = f"{legacy_ingest_fixture.config.file_ingest_baseurl}/legacy/ingest"
+    endpoint_url = f"{legacy_ingest_fixture.config.file_ingest_baseurl}{legacy_ingest_fixture.config.file_ingest_legacy_endpoint}"
     config_path = legacy_ingest_fixture.config.input_dir / "config.yaml"
 
     config = legacy_ingest_fixture.config.model_dump()


### PR DESCRIPTION
Fixed subcommand typo
Added new `file_ingest_federated_endpoint`  and `file_ingest_legacy_endpoint` to make some formerly hardcoded options changeable.
Thanks for pointing out the issues @dontseyit 

As I had to touch one config, I also updated the other configs to use `default=`.