### PR TITLE
Fix PKG_VER regex in PyPI workflow

### DIFF
--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Verify Package Version vs Tag Version
         run: |
-          PKG_VER="$(grep -oP 'version = "\K[^"]+' pyproject.toml)"
+          PKG_VER="$(grep -oP '^version = "\K[^"]+' pyproject.toml)"
           TAG_VER="${GITHUB_REF##*/}"
           echo "Package version is $PKG_VER" >&2
           echo "Tag version is $TAG_VER" >&2


### PR DESCRIPTION
This PR fixes a minor issue in the package version regex in PyPI publish workflow. 

Failed action:
https://github.com/ghga-de/ghga-datasteward-kit/actions/runs/7656571035/job/20865207316

1.1.2 release is broken now we may want delete and re-create.