### PR TITLE
Update legacy config use case

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghga_datasteward_kit"
-version = "1.1.2"
+version = "1.1.3"
 description = "GHGA Data Steward Kit - A utils package for GHGA data stewards."
 dependencies = [
     "crypt4gh >=1.6, <2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_datasteward_kit"
-version = "1.1.2"
+version = "1.1.3"
 description = "GHGA Data Steward Kit - A utils package for GHGA data stewards."
 dependencies = [
     "crypt4gh >=1.6, <2",

--- a/src/ghga_datasteward_kit/batch_s3_upload.py
+++ b/src/ghga_datasteward_kit/batch_s3_upload.py
@@ -26,7 +26,7 @@ from typing import Optional
 
 from pydantic import BaseModel
 
-from ghga_datasteward_kit.s3_upload import Config, load_config_yaml
+from ghga_datasteward_kit.s3_upload import Config, LegacyConfig, load_config_yaml
 
 HERE = Path(__file__).parent
 
@@ -204,7 +204,8 @@ def main(
     Custom script to encrypt data using Crypt4GH and directly uploading it to S3
     objectstorage.
     """
-    config = load_config_yaml(path=config_path, config_cls=Config)
+    config_class = LegacyConfig if legacy_mode else Config
+    config = load_config_yaml(path=config_path, config_cls=config_class)
     files = load_file_metadata(file_overview_tsv=file_overview_tsv)
 
     handle_file_uploads(

--- a/src/ghga_datasteward_kit/batch_s3_upload.py
+++ b/src/ghga_datasteward_kit/batch_s3_upload.py
@@ -22,7 +22,7 @@ import sys
 from copy import copy
 from pathlib import Path
 from time import sleep
-from typing import Optional
+from typing import Optional, Union
 
 from pydantic import BaseModel
 
@@ -204,7 +204,9 @@ def main(
     Custom script to encrypt data using Crypt4GH and directly uploading it to S3
     objectstorage.
     """
-    config_class = LegacyConfig if legacy_mode else Config
+    config_class: type[Union[LegacyConfig, Config]] = (
+        LegacyConfig if legacy_mode else Config
+    )
     config = load_config_yaml(path=config_path, config_cls=config_class)
     files = load_file_metadata(file_overview_tsv=file_overview_tsv)
 


### PR DESCRIPTION
This PR updates the `LegacyConfig` use in `batch_s3_upload` when `legacy_mode` is true. 

When the `legacy-batch-upload` command is called it uses the `Config` which has `secret_ingest_` parameters, then when the generated `legacy-upload` subcommand is called it uses the `LegacyConfig` where `secret_ingest_` parameters are extra. This causes Pydantic validation error in either cases. 