### PR TITLE
Add PCS call for file data deletion

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -18,7 +18,9 @@ services:
         USER_GID: 1000
 
     init: true
-    privileged: true
+
+    extra_hosts:
+      - host.docker.internal:host-gateway
 
     volumes:
       - ..:/workspace:cached

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghga_datasteward_kit"
-version = "1.1.3"
+version = "1.2.0"
 description = "GHGA Data Steward Kit - A utils package for GHGA data stewards."
 dependencies = [
     "crypt4gh >=1.6, <2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_datasteward_kit"
-version = "1.1.3"
+version = "1.2.0"
 description = "GHGA Data Steward Kit - A utils package for GHGA data stewards."
 dependencies = [
     "crypt4gh >=1.6, <2",

--- a/src/ghga_datasteward_kit/cli/file.py
+++ b/src/ghga_datasteward_kit/cli/file.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import typer
 
-from ghga_datasteward_kit import batch_s3_upload, file_ingest, s3_upload
+from ghga_datasteward_kit import batch_s3_upload, file_deletion, file_ingest, s3_upload
 
 cli = typer.Typer()
 
@@ -108,3 +108,18 @@ def ingest_upload_metadata(
             print(f" -{file_path}: {cause}")
     else:
         print("Successfully sent all file upload metadata for ingest.")
+
+
+@cli.command()
+def delete_file(
+    file_id: str = typer.Option(
+        ...,
+        help=(
+            "Path to a tsv file with the first column containing the file path and the"
+            + " second column containing the file alias."
+        ),
+    ),
+    config_path: Path = typer.Option(..., help="Path to a config YAML."),
+):
+    """Call purge controller to remove all data associated with the given file ID from all file services."""
+    file_deletion.main(file_id=file_id, config_path=config_path)

--- a/src/ghga_datasteward_kit/cli/file.py
+++ b/src/ghga_datasteward_kit/cli/file.py
@@ -115,8 +115,7 @@ def delete_file(
     file_id: str = typer.Option(
         ...,
         help=(
-            "Path to a tsv file with the first column containing the file path and the"
-            + " second column containing the file alias."
+            "Public ID of the file for which all associated data across file services should be deleted."
         ),
     ),
     config_path: Path = typer.Option(..., help="Path to a config YAML."),

--- a/src/ghga_datasteward_kit/cli/main.py
+++ b/src/ghga_datasteward_kit/cli/main.py
@@ -108,6 +108,16 @@ def generate_credentials(
         False, help="If specify, overwrite the existing credentials"
     ),
 ):
+    """Generate data steward credentials, save them into file and return hash together with file paths."""
+    generate_steward_credentials(overwrite=overwrite)
+
+
+@cli.command()
+def generate_steward_credentials(
+    overwrite: bool = typer.Option(
+        False, help="If specify, overwrite the existing credentials"
+    ),
+):
     """Generate data steward credentials, save them into file and return hash together with file paths"""
     generate_specific_credentials(overwrite=overwrite, token=STEWARD_TOKEN)
 

--- a/src/ghga_datasteward_kit/cli/main.py
+++ b/src/ghga_datasteward_kit/cli/main.py
@@ -108,7 +108,7 @@ def generate_credentials(
         False, help="If specify, overwrite the existing credentials"
     ),
 ):
-    """Generate credentials, save them into file and return hash together with file paths"""
+    """Generate data steward credentials, save them into file and return hash together with file paths"""
     generate_specific_credentials(overwrite=overwrite, token=STEWARD_TOKEN)
 
 

--- a/src/ghga_datasteward_kit/cli/main.py
+++ b/src/ghga_datasteward_kit/cli/main.py
@@ -23,11 +23,10 @@ from ghga_datasteward_kit import catalog_accession_generator, loading
 from ghga_datasteward_kit.cli.file import cli as file_cli
 from ghga_datasteward_kit.cli.metadata import cli as metadata_cli
 from ghga_datasteward_kit.utils import (
-    TOKEN_HASH_PATH,
-    TOKEN_PATH,
+    DELETION_TOKEN,
+    STEWARD_TOKEN,
+    AuthorizationToken,
     TokenNotExistError,
-    assert_token_exist,
-    save_token_and_hash,
 )
 
 cli = typer.Typer()
@@ -82,6 +81,27 @@ def load(
     loading.load(config_path=config_path)
 
 
+def generate_specific_credentials(overwrite: bool, token: AuthorizationToken):
+    """Common functionality for auth token/token hash pair generation"""
+    if not overwrite:
+        try:
+            token.assert_token_exists()
+        except TokenNotExistError:
+            pass
+        else:
+            typer.echo(
+                'The token file already exist, use the "overwrite" option to overwrite'
+            )
+            raise typer.Abort()
+
+    _, hash_ = token.save_token_and_hash()
+
+    typer.echo("Successfully generated credentials")
+    typer.echo(f"The token can be found in file: {token.token_path}")
+    typer.echo(f"The token hash can be found in file: {token.token_hash_path}")
+    typer.echo(f'The token hash is: "{hash_}"')
+
+
 @cli.command()
 def generate_credentials(
     overwrite: bool = typer.Option(
@@ -89,18 +109,14 @@ def generate_credentials(
     ),
 ):
     """Generate credentials, save them into file and return hash together with file paths"""
-    if not overwrite:
-        try:
-            assert_token_exist()
-        except TokenNotExistError:
-            pass
-        else:
-            typer.echo('The token file already exist, use the "overwrite" to overwrite')
-            raise typer.Abort()
+    generate_specific_credentials(overwrite=overwrite, token=STEWARD_TOKEN)
 
-    _, hash_ = save_token_and_hash()
 
-    typer.echo("Successfully generated credentials")
-    typer.echo(f"The token can be found in file: {TOKEN_PATH}")
-    typer.echo(f"The token hash can be found in file: {TOKEN_HASH_PATH}")
-    typer.echo(f'The token hash: "{hash_}"')
+@cli.command()
+def generate_deletion_credentials(
+    overwrite: bool = typer.Option(
+        False, help="If specify, overwrite the existing credentials"
+    ),
+):
+    """Generate file deletion credentials, save them into file and return hash together with file paths"""
+    generate_specific_credentials(overwrite=overwrite, token=DELETION_TOKEN)

--- a/src/ghga_datasteward_kit/config.py
+++ b/src/ghga_datasteward_kit/config.py
@@ -15,6 +15,7 @@
 
 """Collection of all config classes."""
 
+from ghga_datasteward_kit.file_deletion import FileDeletionConfig
 from ghga_datasteward_kit.file_ingest import IngestConfig
 from ghga_datasteward_kit.loading import LoadConfig
 from ghga_datasteward_kit.metadata import MetadataConfig
@@ -22,6 +23,7 @@ from ghga_datasteward_kit.s3_upload import Config as S3UploadConfig
 
 CONFIG_CLASSES = {
     "s3_upload": S3UploadConfig,
+    "purge": FileDeletionConfig,
     "metadata": MetadataConfig,
     "load": LoadConfig,
     "ingest": IngestConfig,

--- a/src/ghga_datasteward_kit/file_deletion.py
+++ b/src/ghga_datasteward_kit/file_deletion.py
@@ -51,7 +51,11 @@ def main(*, file_id: str, config_path: Path):
     """Call PCS to delete all data in the file services for the given file ID."""
     config = load_config_yaml(path=config_path, config_cls=FileDeletionConfig)
 
-    url = f"{config.file_deletion_baseurl}{config.file_deletion_endpoint}/{file_id}"
+    # custom solution, as urllib.parse.urljoin has some problems with the middle part
+    base = config.file_deletion_baseurl.rstrip("/")
+    endpoint = config.file_deletion_endpoint.strip("/")
+    url = f"{base}/{endpoint}/{file_id}"
+
     token = DELETION_TOKEN.read_token()
     headers = httpx.Headers({"Authorization": f"Bearer {token}"})
 

--- a/src/ghga_datasteward_kit/file_deletion.py
+++ b/src/ghga_datasteward_kit/file_deletion.py
@@ -33,7 +33,7 @@ class FileDeletionConfig(BaseSettings):
     file_deletion_baseurl: str = Field(
         default=...,
         description=(
-            "Base URL under which the delete /files endpoint is available."
+            "Base URL under which the file deletion endpoint is available."
             + " This is an endpoint exposed by GHGA Central. This value is provided by"
             + " GHGA Central on demand."
         ),

--- a/src/ghga_datasteward_kit/file_deletion.py
+++ b/src/ghga_datasteward_kit/file_deletion.py
@@ -12,23 +12,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
-"""Data loading related functionality."""
 from pathlib import Path
 
-from metldata.load.client import upload_artifacts_via_http_api as upload_metadata
-from metldata.load.config import ArtifactLoaderClientConfig
-
-from ghga_datasteward_kit.utils import STEWARD_TOKEN, load_config_yaml
+from pydantic import Field, SecretStr, field_validator
+from pydantic_settings import BaseSettings
 
 
-class LoadConfig(ArtifactLoaderClientConfig):
-    """Load Config"""
+class FileDeletionConfig(BaseException):
+    """TODO"""
 
 
-def load(*, config_path: Path) -> None:
-    """Load file and metadata artifacts to the loader API."""
-    config = load_config_yaml(path=config_path, config_cls=LoadConfig)
-    token = STEWARD_TOKEN.read_token()
-
-    upload_metadata(config=config, token=token)
+def main(file_id: str, config_path: Path):
+    """TODO"""

--- a/src/ghga_datasteward_kit/file_deletion.py
+++ b/src/ghga_datasteward_kit/file_deletion.py
@@ -47,7 +47,7 @@ class FileDeletionConfig(BaseSettings):
     )
 
 
-def main(file_id: str, config_path: Path):
+def main(*, file_id: str, config_path: Path):
     """Call PCS to delete all data in the file services for the given file ID."""
     config = load_config_yaml(path=config_path, config_cls=FileDeletionConfig)
 

--- a/src/ghga_datasteward_kit/file_ingest.py
+++ b/src/ghga_datasteward_kit/file_ingest.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Interaction with file ingest service"""
 
+import urllib.parse
 from pathlib import Path
 from typing import Callable
 
@@ -134,7 +135,7 @@ def file_ingest(
         output_metadata = models.LegacyOutputMetadata.load(input_path=in_path)
         endpoint = config.file_ingest_legacy_endpoint
 
-    endpoint_url = f"{config.file_ingest_baseurl}{endpoint}"
+    endpoint_url = urllib.parse.urljoin(base=config.file_ingest_baseurl, url=endpoint)
 
     submission_store = SubmissionStore(config=config)
 

--- a/src/ghga_datasteward_kit/file_ingest.py
+++ b/src/ghga_datasteward_kit/file_ingest.py
@@ -101,7 +101,7 @@ def main(
 ):
     """Handle ingestion of a folder of s3 upload file metadata"""
     config = utils.load_config_yaml(path=config_path, config_cls=IngestConfig)
-    token = utils.read_token()
+    token = utils.STEWARD_TOKEN.read_token()
 
     errors = {}
 

--- a/src/ghga_datasteward_kit/s3_upload/entrypoint.py
+++ b/src/ghga_datasteward_kit/s3_upload/entrypoint.py
@@ -37,7 +37,7 @@ from ghga_datasteward_kit.s3_upload.utils import (
     handle_superficial_error,
     httpx_client,
 )
-from ghga_datasteward_kit.utils import load_config_yaml, read_token
+from ghga_datasteward_kit.utils import STEWARD_TOKEN, load_config_yaml
 
 
 async def validate_and_transfer_content(
@@ -236,7 +236,7 @@ def main(
     """
     config = load_config_yaml(config_path, Config)
 
-    token = read_token()
+    token = STEWARD_TOKEN.read_token()
     asyncio.run(
         async_main(input_path=input_path, alias=alias, config=config, token=token)
     )

--- a/src/ghga_datasteward_kit/s3_upload/entrypoint.py
+++ b/src/ghga_datasteward_kit/s3_upload/entrypoint.py
@@ -19,6 +19,7 @@
 import asyncio
 import base64
 import logging
+import urllib.parse
 from pathlib import Path
 
 import typer
@@ -104,7 +105,9 @@ async def exchange_secret_for_id(
     If storing the secret fails, the uploaded file is deleted from object storage and
     a ValueError is raised containing the file alias and response status code.
     """
-    endpoint_url = f"{config.secret_ingest_baseurl}/federated/ingest_secret"
+    endpoint_url = urllib.parse.urljoin(
+        base=config.secret_ingest_baseurl, url="/federated/ingest_secret"
+    )
     file_secret = base64.b64encode(secret).decode("utf-8")
     payload = encrypt(data=file_secret, key=config.secret_ingest_pubkey)
     encrypted_secret = models.EncryptedPayload(payload=payload)

--- a/src/ghga_datasteward_kit/utils.py
+++ b/src/ghga_datasteward_kit/utils.py
@@ -37,7 +37,7 @@ class TokenNotExistError(RuntimeError):
 
 @dataclass
 class AuthorizationToken:
-    """TODO"""
+    """Wrapper class to bundle functionality for different tokens used for file service authorization"""
 
     token_path: Path
     token_hash_path: Path

--- a/tests/fixtures/file_deletion_config.yaml
+++ b/tests/fixtures/file_deletion_config.yaml
@@ -1,0 +1,2 @@
+file_deletion_baseurl: https://not-a-valid-url
+file_deletion_endpoint: /files

--- a/tests/test_file_deletion.py
+++ b/tests/test_file_deletion.py
@@ -33,7 +33,9 @@ def test_pcs_call(caplog, monkeypatch, httpx_mock, tmp_path, file_id: str):
     # only capture file deletion logs
     caplog.set_level(logging.INFO, logger="ghga_datasteward_kit.file_deletion")
     config = load_config_yaml(path=CONFIG_PATH, config_cls=FileDeletionConfig)
-    url = f"{config.file_deletion_baseurl}{config.file_deletion_endpoint}/{file_id}"
+    base = config.file_deletion_baseurl.rstrip("/")
+    endpoint = config.file_deletion_endpoint.strip("/")
+    url = f"{base}/{endpoint}/{file_id}"
 
     # mock endpoints
     if file_id == "exists":

--- a/tests/test_file_deletion.py
+++ b/tests/test_file_deletion.py
@@ -1,0 +1,60 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for PCS file deletion call."""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from ghga_datasteward_kit import file_deletion
+from ghga_datasteward_kit.utils import DELETION_TOKEN, load_config_yaml
+
+CONFIG_PATH = Path(__file__).parent / "fixtures" / "file_deletion_config.yaml"
+
+
+@pytest.mark.parametrize("file_id", ["exists", "fake"])
+def test_pcs_call(caplog, monkeypatch, httpx_mock, tmp_path, file_id: str):
+    """Call mock endpoint to validate client functionality."""
+    # only capture file deletion logs
+    caplog.set_level(logging.INFO, logger="ghga_datasteward_kit.file_deletion")
+    config = load_config_yaml(
+        path=CONFIG_PATH, config_cls=file_deletion.FileDeletionConfig
+    )
+    url = f"{config.file_deletion_baseurl}{config.file_deletion_endpoint}/{file_id}"
+
+    # mock endpoints
+    if file_id == "exists":
+        httpx_mock.add_response(method="DELETE", url=url, status_code=202)
+        message = f"Successfully sent deletion request for file '{file_id}'."
+    else:
+        status_code = 404
+        httpx_mock.add_response(method="DELETE", url=url, status_code=status_code)
+        message = (
+            f"Deletion request to '{url}' failed with response code {status_code}."
+        )
+
+    caplog.clear()
+    with monkeypatch.context() as patch:
+        # set up token in tmp dir for testing
+        patch.setattr(DELETION_TOKEN, "token_path", tmp_path / "_token.txt")
+        patch.setattr(DELETION_TOKEN, "token_hash_path", tmp_path / "_token_hash.txt")
+        DELETION_TOKEN.save_token_and_hash()
+
+        file_deletion.main(file_id=file_id, config_path=CONFIG_PATH)
+
+        assert len(caplog.messages) == 1
+        assert message in caplog.messages

--- a/tests/test_file_deletion.py
+++ b/tests/test_file_deletion.py
@@ -20,7 +20,8 @@ from pathlib import Path
 
 import pytest
 
-from ghga_datasteward_kit import file_deletion
+from ghga_datasteward_kit.cli.file import delete_file
+from ghga_datasteward_kit.config import FileDeletionConfig
 from ghga_datasteward_kit.utils import DELETION_TOKEN, load_config_yaml
 
 CONFIG_PATH = Path(__file__).parent / "fixtures" / "file_deletion_config.yaml"
@@ -31,9 +32,7 @@ def test_pcs_call(caplog, monkeypatch, httpx_mock, tmp_path, file_id: str):
     """Call mock endpoint to validate client functionality."""
     # only capture file deletion logs
     caplog.set_level(logging.INFO, logger="ghga_datasteward_kit.file_deletion")
-    config = load_config_yaml(
-        path=CONFIG_PATH, config_cls=file_deletion.FileDeletionConfig
-    )
+    config = load_config_yaml(path=CONFIG_PATH, config_cls=FileDeletionConfig)
     url = f"{config.file_deletion_baseurl}{config.file_deletion_endpoint}/{file_id}"
 
     # mock endpoints
@@ -54,7 +53,7 @@ def test_pcs_call(caplog, monkeypatch, httpx_mock, tmp_path, file_id: str):
         patch.setattr(DELETION_TOKEN, "token_hash_path", tmp_path / "_token_hash.txt")
         DELETION_TOKEN.save_token_and_hash()
 
-        file_deletion.main(file_id=file_id, config_path=CONFIG_PATH)
+        delete_file(file_id=file_id, config_path=CONFIG_PATH)
 
         assert len(caplog.messages) == 1
         assert message in caplog.messages

--- a/tests/test_file_ingest.py
+++ b/tests/test_file_ingest.py
@@ -79,7 +79,6 @@ async def test_legacy_ingest_directly(
         base=legacy_ingest_fixture.config.file_ingest_baseurl,
         url=legacy_ingest_fixture.config.file_ingest_legacy_endpoint,
     )
-    raise ValueError(endpoint_url, legacy_ingest_fixture.config.file_ingest_baseurl)
     token = generate_token()
 
     httpx_mock.add_response(

--- a/tests/test_file_ingest.py
+++ b/tests/test_file_ingest.py
@@ -15,6 +15,8 @@
 
 """File ingest tests."""
 
+import urllib.parse
+
 import pytest
 import yaml
 from ghga_service_commons.utils.simple_token import generate_token
@@ -73,7 +75,11 @@ async def test_legacy_ingest_directly(
     httpx_mock: HTTPXMock,
 ):
     """Test file_ingest function directly"""
-    endpoint_url = f"{legacy_ingest_fixture.config.file_ingest_baseurl}{legacy_ingest_fixture.config.file_ingest_legacy_endpoint}"
+    endpoint_url = urllib.parse.urljoin(
+        base=legacy_ingest_fixture.config.file_ingest_baseurl,
+        url=legacy_ingest_fixture.config.file_ingest_legacy_endpoint,
+    )
+    raise ValueError(endpoint_url, legacy_ingest_fixture.config.file_ingest_baseurl)
     token = generate_token()
 
     httpx_mock.add_response(
@@ -117,7 +123,10 @@ async def test_ingest_directly(
     httpx_mock: HTTPXMock,
 ):
     """Test file_ingest function directly"""
-    endpoint_url = f"{ingest_fixture.config.file_ingest_baseurl}{ingest_fixture.config.file_ingest_federated_endpoint}"
+    endpoint_url = urllib.parse.urljoin(
+        base=ingest_fixture.config.file_ingest_baseurl,
+        url=ingest_fixture.config.file_ingest_federated_endpoint,
+    )
     token = generate_token()
 
     httpx_mock.add_response(url=endpoint_url, status_code=202)
@@ -160,7 +169,10 @@ async def test_legacy_main(
     httpx_mock: HTTPXMock,
 ):
     """Test if main file ingest function works correctly"""
-    endpoint_url = f"{legacy_ingest_fixture.config.file_ingest_baseurl}{legacy_ingest_fixture.config.file_ingest_legacy_endpoint}"
+    endpoint_url = urllib.parse.urljoin(
+        base=legacy_ingest_fixture.config.file_ingest_baseurl,
+        url=legacy_ingest_fixture.config.file_ingest_legacy_endpoint,
+    )
     config_path = legacy_ingest_fixture.config.input_dir / "config.yaml"
 
     config = legacy_ingest_fixture.config.model_dump()


### PR DESCRIPTION
Added a file subcommand to actually call PCS to delete all file service data for a given file ID.

Refactored token code to support and use a separate token for authorization against PCS.
Added simple test case to check basic command behavior.
Bumped minor version.