### PR TITLE
Fix WKVS response handling

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghga_datasteward_kit"
-version = "3.0.1"
+version = "3.0.2"
 description = "GHGA Data Steward Kit - A utils package for GHGA data stewards."
 dependencies = [
     "crypt4gh >=1.6, <2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_datasteward_kit"
-version = "3.0.1"
+version = "3.0.2"
 description = "GHGA Data Steward Kit - A utils package for GHGA data stewards."
 dependencies = [
     "crypt4gh >=1.6, <2",

--- a/src/ghga_datasteward_kit/s3_upload/utils.py
+++ b/src/ghga_datasteward_kit/s3_upload/utils.py
@@ -118,12 +118,11 @@ def retrieve_endpoint_urls(config: LegacyConfig, value_name: str = "storage_alia
     if status_code != 200:
         raise ValueError(f"Received unexpected response code {status_code} from {url}.")
     try:
-        value = response.json()[value_name]
+        return response.json()[value_name]
     except KeyError as err:
         raise ValueError(
             f"Response from {url} did not include expected field '{value_name}'"
         ) from err
-    return value
 
 
 def get_segments(part: bytes, segment_size: int):

--- a/tests/test_s3_upload.py
+++ b/tests/test_s3_upload.py
@@ -72,7 +72,7 @@ async def test_legacy_process(
         )
         httpx_mock.add_response(
             url=path_join(config.wkvs_api_url, "values/storage_aliases"),
-            json={"test": f"{s3_config.s3_endpoint_url}"},
+            json={"storage_aliases": {"test": s3_config.s3_endpoint_url}},
             status_code=200,
         )
         storage = get_object_storage(config=config)
@@ -116,7 +116,7 @@ async def test_process(config_fixture: Config, monkeypatch, httpx_mock: HTTPXMoc
         )
         httpx_mock.add_response(
             url=path_join(config.wkvs_api_url, "values/storage_aliases"),
-            json={"test": f"{s3_config.s3_endpoint_url}"},
+            json={"storage_aliases": {"test": s3_config.s3_endpoint_url}},
             status_code=200,
         )
         storage = get_object_storage(config=config)


### PR DESCRIPTION
Found another bug in how the S3 urls are fetched from WKVS. The response is actually an object, from which the value must be accessed using the value name.