### PR TITLE
Request timeout/retries now user configurable

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghga_datasteward_kit"
-version = "4.0.1"
+version = "4.1.0"
 description = "GHGA Data Steward Kit - A utils package for GHGA data stewards."
 dependencies = [
     "crypt4gh >=1.6, <2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_datasteward_kit"
-version = "4.0.1"
+version = "4.1.0"
 description = "GHGA Data Steward Kit - A utils package for GHGA data stewards."
 dependencies = [
     "crypt4gh >=1.6, <2",

--- a/src/ghga_datasteward_kit/s3_upload/config.py
+++ b/src/ghga_datasteward_kit/s3_upload/config.py
@@ -18,7 +18,7 @@
 import subprocess  # nosec
 from pathlib import Path
 
-from pydantic import Field, SecretStr, field_validator
+from pydantic import Field, NonNegativeInt, SecretStr, field_validator
 from pydantic_settings import BaseSettings
 
 
@@ -102,6 +102,13 @@ class LegacyConfig(S3ObjectStoragesConfig):
     wkvs_api_url: str = Field(
         default="https://data.ghga.de/.well-known",
         description="URL to the root of the WKVS API. Should start with https://.",
+    )
+    client_timeout: NonNegativeInt = Field(
+        default=60, description="Timeout for client requests in seconds"
+    )
+    client_num_retries: NonNegativeInt = Field(
+        default=5,
+        description="Number of times a request should be retried on non critical errors.",
     )
 
     @field_validator("output_dir")

--- a/src/ghga_datasteward_kit/s3_upload/downloader.py
+++ b/src/ghga_datasteward_kit/s3_upload/downloader.py
@@ -55,12 +55,12 @@ class ChunkedDownloader:
 
     def _download_parts(self, download_url):
         """Download file parts"""
-        for part_no, (start, stop) in enumerate(
+        for part_number, (start, stop) in enumerate(
             get_ranges(file_size=self.file_size, part_size=self.config.part_size),
             start=1,
         ):
             headers = {"Range": f"bytes={start}-{stop}"}
-            LOG.debug("Downloading part number %i. %s", part_no, headers)
+            LOG.debug("Downloading part number %i. %s", part_number, headers)
             try:
                 with httpx_client() as client:
                     response = client.get(download_url, headers=headers)
@@ -70,7 +70,9 @@ class ChunkedDownloader:
                 KeyboardInterrupt,
             ) as exc:
                 raise self.storage_cleaner.PartDownloadError(
-                    bucket_id=get_bucket_id(self.config), object_id=self.file_id
+                    bucket_id=get_bucket_id(self.config),
+                    object_id=self.file_id,
+                    part_number=part_number,
                 ) from exc
 
     async def download(self):

--- a/src/ghga_datasteward_kit/s3_upload/entrypoint.py
+++ b/src/ghga_datasteward_kit/s3_upload/entrypoint.py
@@ -30,6 +30,7 @@ from ghga_datasteward_kit.s3_upload.downloader import ChunkedDownloader
 from ghga_datasteward_kit.s3_upload.uploader import ChunkedUploader
 from ghga_datasteward_kit.s3_upload.utils import (
     LOG,
+    HttpxClientConfig,
     StorageCleaner,
     check_adjust_part_size,
     check_output_path,
@@ -129,6 +130,10 @@ async def async_main(input_path: Path, alias: str, config: Config, token: str):
     Run encryption, upload and validation.
     Prints metadata to <alias>.json in the specified output directory
     """
+    HttpxClientConfig.configure(
+        num_retries=config.client_num_retries, timeout=config.client_timeout
+    )
+
     async with StorageCleaner(config=config) as storage_cleaner:
         uploader, file_size = await validate_and_transfer_content(
             input_path=input_path,
@@ -183,6 +188,10 @@ async def legacy_async_main(input_path: Path, alias: str, config: LegacyConfig):
     Run encryption, upload and validation.
     Prints metadata to <alias>.json in the specified output directory
     """
+    HttpxClientConfig.configure(
+        num_retries=config.client_num_retries, timeout=config.client_timeout
+    )
+
     async with StorageCleaner(config=config) as storage_cleaner:
         uploader, file_size = await validate_and_transfer_content(
             input_path=input_path,

--- a/src/ghga_datasteward_kit/s3_upload/utils.py
+++ b/src/ghga_datasteward_kit/s3_upload/utils.py
@@ -202,7 +202,7 @@ def check_adjust_part_size(config: LegacyConfig, file_size: int):
 
     if part_size != config.part_size * 1024**2:
         LOG.info(
-            "Part size was adjusted from %iMiB to %iMiB.\nThe configured part size would either have yielded more than the supported 10.000 parts or was not withing ",
+            "Part size was adjusted from %iMiB to %iMiB.\nThe configured part size would either have yielded more than the supported 10.000 parts or was not within the expected bounds (5MiB <= part_size <= 5GiB).",
             config.part_size,
             part_size / 1024**2,
         )

--- a/src/ghga_datasteward_kit/s3_upload/utils.py
+++ b/src/ghga_datasteward_kit/s3_upload/utils.py
@@ -29,17 +29,27 @@ from ghga_datasteward_kit.s3_upload.config import LegacyConfig
 from ghga_datasteward_kit.utils import path_join
 
 LOG = logging.getLogger("s3_upload")
-NUM_RETRIES = 5
-PART_SIZE = 16 * 1024**2
-TIMEOUT = 60
+
+
+class HttpxClientConfig:
+    """Helper for user configurable httpx request parameters."""
+
+    num_retries: int = 5
+    timeout: int = 60
+
+    @classmethod
+    def configure(cls, num_retries: int, timeout: int):
+        """Set timeout in seconds"""
+        cls.num_retries = num_retries
+        cls.timeout = timeout
 
 
 @contextmanager
 def httpx_client():
     """Yields a context manager httpx client and closes it afterward"""
-    transport = httpx.HTTPTransport(retries=NUM_RETRIES)
+    transport = httpx.HTTPTransport(retries=HttpxClientConfig.num_retries)
 
-    with httpx.Client(transport=transport, timeout=TIMEOUT) as client:
+    with httpx.Client(transport=transport, timeout=HttpxClientConfig.timeout) as client:
         yield client
 
 
@@ -112,17 +122,20 @@ def retrieve_endpoint_urls(config: LegacyConfig, value_name: str = "storage_alia
         try:
             response = client.get(url)
         except httpx.RequestError:
-            LOG.error(f"Could not retrieve data from {url} due to connection issues.")
+            LOG.error(f"Could not retrieve data from {
+                      url} due to connection issues.")
             raise
 
     status_code = response.status_code
     if status_code != 200:
-        raise ValueError(f"Received unexpected response code {status_code} from {url}.")
+        raise ValueError(f"Received unexpected response code {
+                         status_code} from {url}.")
     try:
         return response.json()[value_name]
     except KeyError as err:
         raise ValueError(
-            f"Response from {url} did not include expected field '{value_name}'"
+            f"Response from {
+                url} did not include expected field '{value_name}'"
         ) from err
 
 
@@ -189,7 +202,7 @@ def check_adjust_part_size(config: LegacyConfig, file_size: int):
 
     if part_size != config.part_size * 1024**2:
         LOG.info(
-            "Part size was adjusted from %iMiB to %iMiB.",
+            "Part size was adjusted from %iMiB to %iMiB.\nThe configured part size would either have yielded more than the supported 10.000 parts or was not withing ",
             config.part_size,
             part_size / 1024**2,
         )
@@ -201,7 +214,8 @@ def check_adjust_part_size(config: LegacyConfig, file_size: int):
 def check_output_path(output_path: Path):
     """Check if we accidentally try to overwrite an already existing metadata file"""
     if output_path.exists():
-        msg = f"Output file {output_path.resolve()} already exists and cannot be overwritten."
+        msg = f"Output file {output_path.resolve(
+        )} already exists and cannot be overwritten."
         handle_superficial_error(msg=msg)
 
 
@@ -221,30 +235,44 @@ class StorageCleaner:
     class MultipartUploadCompletionError(RuntimeError):
         """Raised when upload completion failed and the ongoing upload needs to be aborted."""
 
-        def __init__(self, *, bucket_id: str, object_id: str, upload_id: str) -> None:
+        def __init__(
+            self, *, cause: str, bucket_id: str, object_id: str, upload_id: str
+        ) -> None:
             self.bucket_id = bucket_id
             self.object_id = object_id
             self.upload_id = upload_id
-            message = f"Failed completing file upload for ''{object_id}''."
+            message = f"Failed completing file upload for ''{
+                object_id}'' due to:\n {cause}."
             super().__init__(message)
 
     class PartDownloadError(RuntimeError):
         """Raised when downloading a file part failed and the uploaded file needs removal."""
 
-        def __init__(self, *, bucket_id: str, object_id: str):
+        def __init__(self, *, bucket_id: str, object_id: str, part_number: int):
             self.bucket_id = bucket_id
             self.object_id = object_id
-            message = f"Failed downloading file part for ''{object_id}''."
+            message = f"Failed downloading file part {
+                part_number} for ''{object_id}''."
             super().__init__(message)
 
     class PartUploadError(RuntimeError):
         """Raised when uploading a file part failed and the ongoing upload needs to be aborted."""
 
-        def __init__(self, *, bucket_id: str, object_id: str, upload_id: str) -> None:
+        def __init__(
+            self,
+            *,
+            cause: str,
+            bucket_id: str,
+            object_id: str,
+            part_number: int,
+            upload_id: str,
+        ) -> None:
             self.bucket_id = bucket_id
             self.object_id = object_id
+            self.part_number = part_number
             self.upload_id = upload_id
-            message = f"Failed uploading file part for ''{object_id}''."
+            message = f"Failed uploading file part {
+                part_number} for ''{object_id}'' due to:\n {cause}."
             super().__init__(message)
 
     class SecretExchangeError(RuntimeError):


### PR DESCRIPTION
Upload errors now include underlying error directly in message string to reduce crawling through the stack trace.
Non 200 part upload responses now raise an exception after internal httpx retries.

Also bumped minor version.