### PR TITLE
Fix download memory consumption

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghga_datasteward_kit"
-version = "4.2.0"
+version = "4.2.1"
 description = "GHGA Data Steward Kit - A utils package for GHGA data stewards."
 dependencies = [
     "crypt4gh >=1.6, <2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_datasteward_kit"
-version = "4.2.0"
+version = "4.2.1"
 description = "GHGA Data Steward Kit - A utils package for GHGA data stewards."
 dependencies = [
     "crypt4gh >=1.6, <2",

--- a/src/ghga_datasteward_kit/models.py
+++ b/src/ghga_datasteward_kit/models.py
@@ -116,7 +116,7 @@ class OutputMetadata(Metadata):
         output["Symmetric file encryption secret ID"] = self.secret_id
 
         if not output_path.parent.exists():
-            output_path.mkdir(parents=True)
+            output_path.parent.mkdir(parents=True)
 
         # owner read-only
         with output_path.open("w") as file:

--- a/src/ghga_datasteward_kit/s3_upload/file_decryption.py
+++ b/src/ghga_datasteward_kit/s3_upload/file_decryption.py
@@ -147,7 +147,7 @@ class Decryptor:
             avg_speed = (part_number * (self.part_size / 1024**2)) / delta
 
             LOG.info(
-                "\n(5/7) Downloading part %i/%i (%.2f MiB/s)",
+                "(5/7) Downloading part %i/%i (%.2f MiB/s)",
                 part_number,
                 self.num_parts,
                 avg_speed,

--- a/src/ghga_datasteward_kit/s3_upload/file_decryption.py
+++ b/src/ghga_datasteward_kit/s3_upload/file_decryption.py
@@ -46,8 +46,6 @@ class Decryptor:
             self.upload_checksum = upload_checksum
             super().__init__(message)
 
-            super().__init__(message)
-
     class PartChecksumValidationError(RuntimeError):
         """Raised when checksum validation failed and the uploaded file needs removal."""
 

--- a/src/ghga_datasteward_kit/s3_upload/utils.py
+++ b/src/ghga_datasteward_kit/s3_upload/utils.py
@@ -18,7 +18,7 @@
 import logging
 import sys
 from collections.abc import Iterator
-from contextlib import asynccontextmanager, contextmanager
+from contextlib import asynccontextmanager
 from io import BufferedReader
 from pathlib import Path
 

--- a/src/ghga_datasteward_kit/s3_upload/utils.py
+++ b/src/ghga_datasteward_kit/s3_upload/utils.py
@@ -18,7 +18,7 @@
 import logging
 import sys
 from collections.abc import Iterator
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, contextmanager
 from io import BufferedReader
 from pathlib import Path
 


### PR DESCRIPTION
Following changes are included:
- httpx client session is now properly passed around
- part checksums are verified on the fly
- simplified decryption + download processing code
- added explicit gc call to deal with stale allocations for large part sizes during download. Part size of a 100 MiB should now require ~ 1GB RAM
- fixed path for missing output folder creation
- new pre-signed URL is now retrieved for each part during download so extremely long running verification downloads shouldn't run into any issues due to invalid URLs 