### PR TITLE
Transfer parallelization

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -52,7 +52,8 @@
 				"visualstudioexptteam.vscodeintellicode",
 				"ymotongpoo.licenser",
 				"charliermarsh.ruff",
-				"ms-python.mypy-type-checker"
+				"ms-python.mypy-type-checker",
+				"-ms-python.autopep8"
 			]
 		}
 	},

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghga_datasteward_kit"
-version = "4.2.1"
+version = "4.3.0"
 description = "GHGA Data Steward Kit - A utils package for GHGA data stewards."
 dependencies = [
     "crypt4gh >=1.6, <2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_datasteward_kit"
-version = "4.2.1"
+version = "4.3.0"
 description = "GHGA Data Steward Kit - A utils package for GHGA data stewards."
 dependencies = [
     "crypt4gh >=1.6, <2",

--- a/src/ghga_datasteward_kit/models.py
+++ b/src/ghga_datasteward_kit/models.py
@@ -197,7 +197,7 @@ class LegacyOutputMetadata(LegacyMetadata):
         output["Symmetric file encryption secret"] = self.file_secret
 
         if not output_path.parent.exists():
-            output_path.mkdir(parents=True)
+            output_path.parent.mkdir(parents=True)
 
         # owner read-only
         with output_path.open("w") as file:

--- a/src/ghga_datasteward_kit/s3_upload/config.py
+++ b/src/ghga_datasteward_kit/s3_upload/config.py
@@ -113,7 +113,7 @@ class LegacyConfig(S3ObjectStoragesConfig):
     )
     client_max_parallel_transfers: PositiveInt = Field(
         default=10,
-        description="Maximum number of inflight part upload or part download requests.",
+        description="Maximum number of ongoing concurrent part uploads or downloads.",
     )
     client_num_retries: NonNegativeInt = Field(
         default=5,

--- a/src/ghga_datasteward_kit/s3_upload/config.py
+++ b/src/ghga_datasteward_kit/s3_upload/config.py
@@ -112,7 +112,7 @@ class LegacyConfig(S3ObjectStoragesConfig):
         default=60, description="Timeout for client requests in seconds"
     )
     client_max_parallel_transfers: PositiveInt = Field(
-        default=5,
+        default=10,
         description="Maximum number of inflight part upload or part download requests.",
     )
     client_num_retries: NonNegativeInt = Field(

--- a/src/ghga_datasteward_kit/s3_upload/config.py
+++ b/src/ghga_datasteward_kit/s3_upload/config.py
@@ -111,7 +111,10 @@ class LegacyConfig(S3ObjectStoragesConfig):
     client_timeout: NonNegativeInt | None = Field(
         default=60, description="Timeout for client requests in seconds"
     )
-    client_max_parallel_transfers: PositiveInt = Field(default=5, description="")
+    client_max_parallel_transfers: PositiveInt = Field(
+        default=5,
+        description="Maximum number of inflight part upload or part download requests.",
+    )
     client_num_retries: NonNegativeInt = Field(
         default=5,
         description="Number of times a request should be retried on non critical errors.",

--- a/src/ghga_datasteward_kit/s3_upload/config.py
+++ b/src/ghga_datasteward_kit/s3_upload/config.py
@@ -18,7 +18,7 @@
 import subprocess  # nosec
 from pathlib import Path
 
-from pydantic import Field, NonNegativeInt, SecretStr, field_validator
+from pydantic import Field, NonNegativeInt, PositiveInt, SecretStr, field_validator
 from pydantic_settings import BaseSettings
 
 
@@ -111,6 +111,7 @@ class LegacyConfig(S3ObjectStoragesConfig):
     client_timeout: NonNegativeInt | None = Field(
         default=60, description="Timeout for client requests in seconds"
     )
+    client_max_parallel_transfers: PositiveInt = Field(default=5, description="")
     client_num_retries: NonNegativeInt = Field(
         default=5,
         description="Number of times a request should be retried on non critical errors.",

--- a/src/ghga_datasteward_kit/s3_upload/downloader.py
+++ b/src/ghga_datasteward_kit/s3_upload/downloader.py
@@ -105,7 +105,10 @@ class ChunkedDownloader:
         next_part_to_yield = 1
         parts_downloaded = 0
         num_parts = math.ceil(self.file_size / self.part_size)
-        # priority queue ensures we get the the part with the lowest part number on calling get
+        # Priority queue ensures we get the the part with the lowest part number on calling get
+        # Due to out of order downloading, in the worst case the next part is fetched last in the
+        # current batch of scheduled tasks and we keep around an additional max_parallel_tasks - 1
+        # parts in the intermediary queue, assuming equal transfer speed for any single part.
         results: PriorityQueue[tuple[int, bytes]] = PriorityQueue()
 
         while next_part_to_yield <= num_parts:

--- a/src/ghga_datasteward_kit/s3_upload/downloader.py
+++ b/src/ghga_datasteward_kit/s3_upload/downloader.py
@@ -100,7 +100,7 @@ class ChunkedDownloader:
             except BaseException as exception:
                 await self._queue.put((part_number, exception))
 
-    async def _drain_from_queue(self):
+    async def _drain_queue(self):
         """Fetch downloaded parts from queue and keep local queue to yield parts in order."""
         next_part_to_yield = 1
         parts_downloaded = 0
@@ -170,7 +170,7 @@ class ChunkedDownloader:
                 )
 
             try:
-                await decryptor.process_parts(self._drain_from_queue())
+                await decryptor.process_parts(self._drain_queue())
 
             except (
                 decryptor.FileChecksumValidationError,

--- a/src/ghga_datasteward_kit/s3_upload/entrypoint.py
+++ b/src/ghga_datasteward_kit/s3_upload/entrypoint.py
@@ -74,16 +74,21 @@ async def validate_and_transfer_content(
     )
     await uploader.encrypt_and_upload()
 
-    downloader = ChunkedDownloader(
-        config=config,
-        file_id=uploader.file_id,
-        encrypted_file_size=uploader.encryptor.encrypted_file_size,
-        file_secret=uploader.encryptor.file_secret,
-        part_size=config.part_size,
-        target_checksums=uploader.encryptor.checksums,
-        storage_cleaner=storage_cleaner,
-    )
-    await downloader.download()
+    try:
+        downloader = ChunkedDownloader(
+            config=config,
+            file_id=uploader.file_id,
+            encrypted_file_size=uploader.encryptor.encrypted_file_size,
+            file_secret=uploader.encryptor.file_secret,
+            part_size=config.part_size,
+            target_checksums=uploader.encryptor.checksums,
+            storage_cleaner=storage_cleaner,
+        )
+        await downloader.download()
+    except KeyboardInterrupt as error:
+        raise storage_cleaner.DownloadError(
+            bucket_id=get_bucket_id(config), object_id=downloader.file_id
+        ) from error
 
     return uploader, file_size
 

--- a/src/ghga_datasteward_kit/s3_upload/file_decryption.py
+++ b/src/ghga_datasteward_kit/s3_upload/file_decryption.py
@@ -18,7 +18,6 @@
 import gc
 import hashlib
 from collections.abc import AsyncGenerator
-from functools import partial
 from time import time
 from typing import Any
 
@@ -118,7 +117,7 @@ class Decryptor:
                 upload_part_checksum=upload_part_sha256,
             )
 
-    async def process_parts(self, download_files: partial[AsyncGenerator[bytes, Any]]):
+    async def process_parts(self, download_files: AsyncGenerator[bytes, Any]):
         """Encrypt and upload file parts."""
         unprocessed_bytes = b""
         download_buffer = b""
@@ -128,7 +127,8 @@ class Decryptor:
 
         part_number = 1
         collection_tracker_mib = 0
-        async for file_part in download_files():
+
+        async for file_part in download_files:
             # process encrypted
             self._validate_current_checksum(
                 file_part=file_part, part_number=part_number

--- a/src/ghga_datasteward_kit/s3_upload/file_decryption.py
+++ b/src/ghga_datasteward_kit/s3_upload/file_decryption.py
@@ -118,7 +118,7 @@ class Decryptor:
             )
 
     async def process_parts(self, download_files: AsyncGenerator[bytes, Any]):
-        """Encrypt and upload file parts."""
+        """Download and decrypt file parts."""
         unprocessed_bytes = b""
         download_buffer = b""
         unencrypted_sha256 = hashlib.sha256()

--- a/src/ghga_datasteward_kit/s3_upload/uploader.py
+++ b/src/ghga_datasteward_kit/s3_upload/uploader.py
@@ -114,6 +114,7 @@ class ChunkedUploader:
                             start=start,
                         )
                     )
+                # Wait for all upload tasks to finish
                 await task_handler.gather()
                 if encrypted_file_size != self.encryptor.encrypted_file_size:
                     raise ValueError(

--- a/src/ghga_datasteward_kit/s3_upload/utils.py
+++ b/src/ghga_datasteward_kit/s3_upload/utils.py
@@ -266,6 +266,15 @@ class StorageCleaner:
             self.object_id = object_id
             super().__init__(message)
 
+    class DownloadError(RuntimeError):
+        """Raised when downloading a file failed due to keyboard interrupts and the uploaded file needs removal."""
+
+        def __init__(self, *, bucket_id: str, object_id: str):
+            self.bucket_id = bucket_id
+            self.object_id = object_id
+            message = f"Failed downloading file for ''{object_id}''."
+            super().__init__(message)
+
     class MultipartUploadCompletionError(RuntimeError):
         """Raised when upload completion failed and the ongoing upload needs to be aborted."""
 

--- a/src/ghga_datasteward_kit/s3_upload/utils.py
+++ b/src/ghga_datasteward_kit/s3_upload/utils.py
@@ -358,6 +358,7 @@ class StorageCleaner:
         if isinstance(
             exc_v,
             self.ChecksumValidationError
+            | self.DownloadError
             | self.PartDownloadError
             | self.SecretExchangeError
             | self.WritingOutputError,

--- a/src/ghga_datasteward_kit/s3_upload/utils.py
+++ b/src/ghga_datasteward_kit/s3_upload/utils.py
@@ -49,6 +49,7 @@ class RequestConfigurator:
         """Set timeout in seconds"""
         cls.timeout = config.client_timeout
         cls.max_connections = config.client_max_parallel_transfers
+        # silence httpx messages on each request due to setting global level info before
         logging.getLogger("httpx").setLevel(logging.WARNING)
 
 


### PR DESCRIPTION
This PR moves both the actual S3 upload and the download for verification purposes to an async task model.
The new `client_max_parallel_transfers` option limits both the size of the httpx connection pool and the amount of inflight requests for file part uploads and downloads.
10 concurrent file transfer operations seems like a sweet spot after some preliminary testing, but there might be a better default.

###  Changes for Upload:
Part uploads are now tasks that get the `self.encryptor.process_file(file=file)` generator passed into to lazily fetch and encrypt file parts in order. The actual httpx requests, however, have no guaranteed order and thus an in sequence number is displayed in the CLI. Error messages will contain the actual part number instead.

### Changes for Download:
File part downloads are also modelled as tasks now. Two priority queues are used to ensure in order processing of downloaded file parts while also limiting the amount of inflight requests. Due to the use of the second queue, RAM usage might be around twice what the upload needs in worst case scenarios - or even more if the download speed between inflight requests varies wildly. To simplify exception handling, encountered exceptions are passed into the queue and raised when trying to process the corresponding part instead.  There is no need for an explicit `await` or `gather` as this is implicitly achieved by `_drain_queue`.

Two open questions remain:
1. Does this need automated tests for parts of the functionality?
2. Should tasks be explicitly cancelled once an exception is encountered for one of them? My naive guess would be no, as excecution should be stopped shortly after for the single upload case, but it might still be necessary to free resources if using batch upload functionality. Though not sure about that one, as they are started as subprocesses

@dontseyit Feel free to tag anyone else who should check this code if the async task part is hard to understand.