### PR TITLE
Fix bucket_id propagation

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghga_datasteward_kit"
-version = "4.3.0"
+version = "4.4.0"
 description = "GHGA Data Steward Kit - A utils package for GHGA data stewards."
 dependencies = [
     "crypt4gh >=1.6, <2",

--- a/README.md
+++ b/README.md
@@ -156,8 +156,8 @@ running system and make the corresponding files available for download.
 
 This command requires a configuration file as described [here](./ingest_config.md).
 
-### ingest version compatibility
-Currently v4.4.0 of this tool and v3.2.0 of the `File Ingest Service` are compatible.
+#### ingest version compatibility
+Currently v4.4.0 of this tool and v4.0.0 of the `File Ingest Service` are compatible.
 
 ### metadata
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This is achieved using the data steward kit, using the following steps:
    `ghga-datasteward-kit files upload` for uploading a single file or the
    `ghga-datasteward-kit files batch-upload` for uploading multiple files at once.
    There also exist legacy versions of these subcommands for compatibility reasons,
-   where the commonad is prefixed with `legacy-`.
+   where the command is prefixed with `legacy-`.
    Please see [this section](#files-batch-upload) for further details. This will output
    one summary JSON per uploaded file. The encryption secret is automatically
    transferred to GHGA central.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ This is achieved using the data steward kit, using the following steps:
    storage is done in one go. This is achieved using either the
    `ghga-datasteward-kit files upload` for uploading a single file or the
    `ghga-datasteward-kit files batch-upload` for uploading multiple files at once.
+   There also exist legacy versions of these subcommands for compatibility reasons,
+   where the commonad is prefixed with `legacy-`.
    Please see [this section](#files-batch-upload) for further details. This will output
    one summary JSON per uploaded file. The encryption secret is automatically
    transferred to GHGA central.
@@ -120,11 +122,9 @@ content to a (remote) S3-compatible object storage.
 This process consists of multiple steps:
 1. Generate a unique file id
 2. Create unencrypted file checksum
-3. Encrypt file
-4. Extract file secret and remove Crypt4GH envelope
-5. Upload encrypted file content
-6. Download encrypted file content, decrypt and verify checksum
-7. Write file/upload information to output file
+3. Encrypt and upload file in chunks
+4. Download encrypted file content, decrypt and verify checksum
+5. Write file/upload information to output file
 
 The user needs to provide a config yaml containing information as described
 [here](./s3_upload_config.md).
@@ -135,11 +135,13 @@ An overview of important information about each the upload is written to a file 
 It contains the following information:
 1. The file alias
 2. A unique identifier for the file
-3. The local file path
-4. A SHA256 checksum over the unencrypted content
-5. MD5 checksums over all encrypted file parts
-6. SHA256 checksums over all encrypted file parts
-7. The file encryption/decryption secret
+3. An identifier of the storage bucket the file was uploaded to (Added in v4.4.0)
+4. The local file path
+5. A SHA256 checksum over the unencrypted content
+6. MD5 checksums over all encrypted file parts
+7. SHA256 checksums over all encrypted file parts
+8. The file encryption/decryption secret id or the actual textual representation of the secret, if the legacy command was used (Secret ID since v1.0.0)
+9. An alias for the storage node the file was uploaded to (Added in v3.0.0)
 
 Attention: Keep this output file in a safe, private location.
 If this file is lost, the uploaded file content becomes inaccessible.
@@ -153,6 +155,9 @@ Upload all file summary JSONs (produced using the
 running system and make the corresponding files available for download.
 
 This command requires a configuration file as described [here](./ingest_config.md).
+
+### ingest version compatibility
+Currently v4.4.0 of this tool and v3.2.0 of the `File Ingest Service` are compatible.
 
 ### metadata
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_datasteward_kit"
-version = "4.3.0"
+version = "4.4.0"
 description = "GHGA Data Steward Kit - A utils package for GHGA data stewards."
 dependencies = [
     "crypt4gh >=1.6, <2",

--- a/src/ghga_datasteward_kit/file_ingest.py
+++ b/src/ghga_datasteward_kit/file_ingest.py
@@ -146,7 +146,7 @@ def file_ingest(
         output_metadata = models.OutputMetadata.load(
             input_path=in_path,
             selected_alias=config.selected_storage_alias,
-            selected_bucket=config.fallback_bucket_id,
+            fallback_bucket=config.fallback_bucket_id,
         )
         endpoint = config.file_ingest_federated_endpoint
         LOG.info("Selected non-legacy endpoint %s for file %s.", endpoint, in_path)
@@ -154,7 +154,7 @@ def file_ingest(
         output_metadata = models.LegacyOutputMetadata.load(
             input_path=in_path,
             selected_alias=config.selected_storage_alias,
-            selected_bucket=config.fallback_bucket_id,
+            fallback_bucket=config.fallback_bucket_id,
         )
         endpoint = config.file_ingest_legacy_endpoint
         LOG.info("Selected legacy endpoint %s for file %s.", endpoint, in_path)

--- a/src/ghga_datasteward_kit/file_ingest.py
+++ b/src/ghga_datasteward_kit/file_ingest.py
@@ -179,7 +179,7 @@ def file_ingest(
             if response.status_code == 403:
                 raise ValueError("Not authorized to access ingest endpoint.")
             if response.status_code == 422:
-                raise ValueError("Could not decrypt received payload.")
+                raise ValueError(response.json()["detail"])
             if response.status_code == 500:
                 raise ValueError(
                     "Internal file ingest service error or communication with vault failed."

--- a/src/ghga_datasteward_kit/file_ingest.py
+++ b/src/ghga_datasteward_kit/file_ingest.py
@@ -187,7 +187,7 @@ def file_ingest(
             if response.status_code == 403:
                 raise ValueError("Not authorized to access ingest endpoint.")
             if response.status_code == 422:
-                raise ValueError(response.json()["detail"])
+                raise ValueError("Could not decrypt received payload.")
             if response.status_code == 500:
                 raise ValueError(
                     "Internal file ingest service error or communication with vault failed."

--- a/src/ghga_datasteward_kit/file_ingest.py
+++ b/src/ghga_datasteward_kit/file_ingest.py
@@ -80,6 +80,10 @@ class IngestConfig(SubmissionStoreConfig):
             + " During the later ingest phase, the alias will be validated by the File Ingest Service."
         ),
     )
+    selected_bucket_id: str = Field(
+        default=...,
+        description="Fallback bucket_id for older output metadata files that don't contain a bucket ID.",
+    )
 
 
 def alias_to_accession(
@@ -140,13 +144,17 @@ def file_ingest(
     """
     try:
         output_metadata = models.OutputMetadata.load(
-            input_path=in_path, selected_alias=config.selected_storage_alias
+            input_path=in_path,
+            selected_alias=config.selected_storage_alias,
+            selected_bucket=config.selected_bucket_id,
         )
         endpoint = config.file_ingest_federated_endpoint
         LOG.info("Selected non-legacy endpoint %s for file %s.", endpoint, in_path)
     except (KeyError, ValidationError):
         output_metadata = models.LegacyOutputMetadata.load(
-            input_path=in_path, selected_alias=config.selected_storage_alias
+            input_path=in_path,
+            selected_alias=config.selected_storage_alias,
+            selected_bucket=config.selected_bucket_id,
         )
         endpoint = config.file_ingest_legacy_endpoint
         LOG.info("Selected legacy endpoint %s for file %s.", endpoint, in_path)

--- a/src/ghga_datasteward_kit/file_ingest.py
+++ b/src/ghga_datasteward_kit/file_ingest.py
@@ -80,7 +80,7 @@ class IngestConfig(SubmissionStoreConfig):
             + " During the later ingest phase, the alias will be validated by the File Ingest Service."
         ),
     )
-    selected_bucket_id: str = Field(
+    fallback_bucket_id: str = Field(
         default=...,
         description="Fallback bucket_id for older output metadata files that don't contain a bucket ID.",
     )
@@ -146,7 +146,7 @@ def file_ingest(
         output_metadata = models.OutputMetadata.load(
             input_path=in_path,
             selected_alias=config.selected_storage_alias,
-            selected_bucket=config.selected_bucket_id,
+            selected_bucket=config.fallback_bucket_id,
         )
         endpoint = config.file_ingest_federated_endpoint
         LOG.info("Selected non-legacy endpoint %s for file %s.", endpoint, in_path)
@@ -154,7 +154,7 @@ def file_ingest(
         output_metadata = models.LegacyOutputMetadata.load(
             input_path=in_path,
             selected_alias=config.selected_storage_alias,
-            selected_bucket=config.selected_bucket_id,
+            selected_bucket=config.fallback_bucket_id,
         )
         endpoint = config.file_ingest_legacy_endpoint
         LOG.info("Selected legacy endpoint %s for file %s.", endpoint, in_path)

--- a/src/ghga_datasteward_kit/file_ingest.py
+++ b/src/ghga_datasteward_kit/file_ingest.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Interaction with file ingest service"""
 
+import logging
 from collections.abc import Callable
 from pathlib import Path
 
@@ -25,6 +26,8 @@ from metldata.submission_registry.submission_store import (
 from pydantic import Field, ValidationError
 
 from ghga_datasteward_kit import models, utils
+
+LOG = logging.getLogger(__name__)
 
 
 class IngestConfig(SubmissionStoreConfig):
@@ -140,11 +143,13 @@ def file_ingest(
             input_path=in_path, selected_alias=config.selected_storage_alias
         )
         endpoint = config.file_ingest_federated_endpoint
+        LOG.info("Selected non-legacy endpoint %s for file %s.", endpoint, in_path)
     except (KeyError, ValidationError):
         output_metadata = models.LegacyOutputMetadata.load(
             input_path=in_path, selected_alias=config.selected_storage_alias
         )
         endpoint = config.file_ingest_legacy_endpoint
+        LOG.info("Selected legacy endpoint %s for file %s.", endpoint, in_path)
 
     endpoint_url = utils.path_join(config.file_ingest_baseurl, endpoint)
 

--- a/src/ghga_datasteward_kit/models.py
+++ b/src/ghga_datasteward_kit/models.py
@@ -244,7 +244,7 @@ class LegacyOutputMetadata(LegacyMetadata):
             bucket_id = data["Bucket ID"]
         except KeyError:
             LOG.warning(
-                "Could not find bucket ID in metadata, populating with configured alias '%s' instead.",
+                "Could not find bucket ID in metadata, populating with configured bucket '%s' instead.",
                 selected_bucket,
             )
             bucket_id = selected_bucket

--- a/src/ghga_datasteward_kit/models.py
+++ b/src/ghga_datasteward_kit/models.py
@@ -129,7 +129,7 @@ class OutputMetadata(Metadata):
         os.chmod(path=output_path, mode=0o400)
 
     @classmethod
-    def load(cls, input_path: Path, selected_alias: str, selected_bucket: str):
+    def load(cls, input_path: Path, selected_alias: str, fallback_bucket: str):
         """Load metadata from serialized file"""
         with input_path.open("r") as infile:
             data = json.load(infile)
@@ -149,9 +149,9 @@ class OutputMetadata(Metadata):
         except KeyError:
             LOG.warning(
                 "Could not find bucket ID in metadata, populating with configured bucket '%s' instead.",
-                selected_bucket,
+                fallback_bucket,
             )
-            bucket_id = selected_bucket
+            bucket_id = fallback_bucket
 
         file_id = data["File UUID"]
         part_size = int(data["Part Size"].rpartition(" MiB")[0]) * 1024**2
@@ -225,7 +225,7 @@ class LegacyOutputMetadata(LegacyMetadata):
         os.chmod(path=output_path, mode=0o400)
 
     @classmethod
-    def load(cls, input_path: Path, selected_alias: str, selected_bucket: str):
+    def load(cls, input_path: Path, selected_alias: str, fallback_bucket: str):
         """Load metadata from serialized file"""
         with input_path.open("r") as infile:
             data = json.load(infile)
@@ -245,9 +245,9 @@ class LegacyOutputMetadata(LegacyMetadata):
         except KeyError:
             LOG.warning(
                 "Could not find bucket ID in metadata, populating with configured bucket '%s' instead.",
-                selected_bucket,
+                fallback_bucket,
             )
-            bucket_id = selected_bucket
+            bucket_id = fallback_bucket
 
         file_id = data["File UUID"]
         part_size = int(data["Part Size"].rpartition(" MiB")[0]) * 1024**2

--- a/src/ghga_datasteward_kit/models.py
+++ b/src/ghga_datasteward_kit/models.py
@@ -148,7 +148,7 @@ class OutputMetadata(Metadata):
             bucket_id = data["Bucket ID"]
         except KeyError:
             LOG.warning(
-                "Could not find bucket ID in metadata, populating with configured alias '%s' instead.",
+                "Could not find bucket ID in metadata, populating with configured bucket '%s' instead.",
                 selected_bucket,
             )
             bucket_id = selected_bucket

--- a/src/ghga_datasteward_kit/models.py
+++ b/src/ghga_datasteward_kit/models.py
@@ -71,7 +71,7 @@ class MetadataBase(BaseModel):
     """Common base for all output and upload models"""
 
     file_id: str
-    bucket_id: str | None
+    bucket_id: str
     object_id: str
     part_size: int
     unencrypted_size: int
@@ -129,7 +129,7 @@ class OutputMetadata(Metadata):
         os.chmod(path=output_path, mode=0o400)
 
     @classmethod
-    def load(cls, input_path: Path, selected_alias: str):
+    def load(cls, input_path: Path, selected_alias: str, selected_bucket: str):
         """Load metadata from serialized file"""
         with input_path.open("r") as infile:
             data = json.load(infile)
@@ -148,11 +148,10 @@ class OutputMetadata(Metadata):
             bucket_id = data["Bucket ID"]
         except KeyError:
             LOG.warning(
-                "Could not find bucket ID in metadata. Configure the selected_bucket_id option in"
-                " the file ingest service to populate older metadata with the correct value."
-                "Output metadata for different buckets needs to be split into different batches in this case."
+                "Could not find bucket ID in metadata, populating with configured alias '%s' instead.",
+                selected_bucket,
             )
-            bucket_id = None
+            bucket_id = selected_bucket
 
         file_id = data["File UUID"]
         part_size = int(data["Part Size"].rpartition(" MiB")[0]) * 1024**2
@@ -226,7 +225,7 @@ class LegacyOutputMetadata(LegacyMetadata):
         os.chmod(path=output_path, mode=0o400)
 
     @classmethod
-    def load(cls, input_path: Path, selected_alias: str):
+    def load(cls, input_path: Path, selected_alias: str, selected_bucket: str):
         """Load metadata from serialized file"""
         with input_path.open("r") as infile:
             data = json.load(infile)
@@ -245,11 +244,10 @@ class LegacyOutputMetadata(LegacyMetadata):
             bucket_id = data["Bucket ID"]
         except KeyError:
             LOG.warning(
-                "Could not find bucket ID in metadata. Configure the selected_bucket_id option in"
-                " the file ingest service to populate older metadata with the correct value."
-                "Output metadata for different buckets needs to be split into different batches in this case."
+                "Could not find bucket ID in metadata, populating with configured alias '%s' instead.",
+                selected_bucket,
             )
-            bucket_id = None
+            bucket_id = selected_bucket
 
         file_id = data["File UUID"]
         part_size = int(data["Part Size"].rpartition(" MiB")[0]) * 1024**2

--- a/src/ghga_datasteward_kit/s3_upload/config.py
+++ b/src/ghga_datasteward_kit/s3_upload/config.py
@@ -119,6 +119,9 @@ class LegacyConfig(S3ObjectStoragesConfig):
         default=5,
         description="Number of times a request should be retried on non critical errors.",
     )
+    debug: bool = Field(
+        default=False, description="Enable debug functionality for upload."
+    )
 
     @field_validator("output_dir")
     def expand_env_vars_output_dir(cls, output_dir: Path):  # noqa: N805

--- a/src/ghga_datasteward_kit/s3_upload/config.py
+++ b/src/ghga_datasteward_kit/s3_upload/config.py
@@ -119,9 +119,6 @@ class LegacyConfig(S3ObjectStoragesConfig):
         default=5,
         description="Number of times a request should be retried on non critical errors.",
     )
-    debug: bool = Field(
-        default=False, description="Enable debug functionality for upload."
-    )
 
     @field_validator("output_dir")
     def expand_env_vars_output_dir(cls, output_dir: Path):  # noqa: N805

--- a/src/ghga_datasteward_kit/s3_upload/entrypoint.py
+++ b/src/ghga_datasteward_kit/s3_upload/entrypoint.py
@@ -163,6 +163,7 @@ async def async_main(input_path: Path, alias: str, config: Config, token: str):
         metadata = models.OutputMetadata(
             alias=uploader.alias,
             file_id=uploader.file_id,
+            bucket_id=get_bucket_id(config=config),
             object_id=uploader.file_id,
             original_path=input_path,
             part_size=config.part_size,
@@ -213,6 +214,7 @@ async def legacy_async_main(input_path: Path, alias: str, config: LegacyConfig):
         metadata = models.LegacyOutputMetadata(
             alias=uploader.alias,
             file_id=uploader.file_id,
+            bucket_id=get_bucket_id(config=config),
             object_id=uploader.file_id,
             original_path=input_path,
             part_size=config.part_size,

--- a/src/ghga_datasteward_kit/s3_upload/entrypoint.py
+++ b/src/ghga_datasteward_kit/s3_upload/entrypoint.py
@@ -70,7 +70,6 @@ async def validate_and_transfer_content(
         config=config,
         unencrypted_file_size=file_size,
         storage_cleaner=storage_cleaner,
-        debug_mode=config.debug,
     )
     await uploader.encrypt_and_upload()
 

--- a/src/ghga_datasteward_kit/s3_upload/uploader.py
+++ b/src/ghga_datasteward_kit/s3_upload/uploader.py
@@ -38,10 +38,6 @@ from ghga_datasteward_kit.s3_upload.utils import (
     httpx_client,
 )
 
-MAX_TIMEOUT_DEBUG = (
-    600  # maximum timeout for upload request used for debugging purposes
-)
-
 
 class UploadTaskHandler:
     """Wraps task scheduling details."""
@@ -63,14 +59,13 @@ class UploadTaskHandler:
 class ChunkedUploader:
     """Handler class dealing with upload functionality"""
 
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         input_path: Path,
         alias: str,
         config: LegacyConfig,
         unencrypted_file_size: int,
         storage_cleaner: StorageCleaner,
-        debug_mode: bool,
     ) -> None:
         self.alias = alias
         self.config = config
@@ -80,7 +75,6 @@ class ChunkedUploader:
         self.unencrypted_file_size = unencrypted_file_size
         self.encrypted_file_size = 0
         self._storage_cleaner = storage_cleaner
-        self.debug_mode = debug_mode
 
     async def encrypt_and_upload(self):
         """Delegate encryption and perform multipart upload"""

--- a/tests/fixtures/ingest.py
+++ b/tests/fixtures/ingest.py
@@ -49,6 +49,9 @@ EXAMPLE_SUBMISSION = Submission(
     ),
 )
 
+SELECTED_STORAGE_ALIAS = "test"
+SELECTED_BUCKET_ID = "selected-test-bucket"
+
 
 @dataclass
 class IngestFixture:
@@ -70,11 +73,12 @@ def legacy_ingest_fixture() -> Generator[IngestFixture, None, None]:
             keypair = generate_key_pair()
 
             file_path = Path(input_dir) / "test.json"
-            file_id = "happy_little_object"
+            file_id = "happy-little-object"
 
             metadata = LegacyOutputMetadata(
                 alias="test_alias",
                 file_id=file_id,
+                bucket_id="test-bucket",
                 object_id=file_id,
                 original_path=file_path,
                 part_size=16 * 1024**2,
@@ -95,7 +99,8 @@ def legacy_ingest_fixture() -> Generator[IngestFixture, None, None]:
                 input_dir=Path(input_dir),
                 map_files_fields=["study_files"],
                 submission_store_dir=Path(submission_store_dir),
-                selected_storage_alias="test",
+                selected_storage_alias=SELECTED_STORAGE_ALIAS,
+                selected_bucket_id=SELECTED_BUCKET_ID,
             )
 
             submission_store = SubmissionStore(config=config)
@@ -124,6 +129,7 @@ def ingest_fixture() -> Generator[IngestFixture, None, None]:
             metadata = OutputMetadata(
                 alias="test_alias",
                 file_id=file_id,
+                bucket_id="test-bucket",
                 object_id=file_id,
                 original_path=file_path,
                 part_size=16 * 1024**2,
@@ -144,7 +150,8 @@ def ingest_fixture() -> Generator[IngestFixture, None, None]:
                 input_dir=Path(input_dir),
                 map_files_fields=["study_files"],
                 submission_store_dir=Path(submission_store_dir),
-                selected_storage_alias="test",
+                selected_storage_alias=SELECTED_STORAGE_ALIAS,
+                selected_bucket_id=SELECTED_BUCKET_ID,
             )
 
             submission_store = SubmissionStore(config=config)

--- a/tests/fixtures/ingest.py
+++ b/tests/fixtures/ingest.py
@@ -100,7 +100,7 @@ def legacy_ingest_fixture() -> Generator[IngestFixture, None, None]:
                 map_files_fields=["study_files"],
                 submission_store_dir=Path(submission_store_dir),
                 selected_storage_alias=SELECTED_STORAGE_ALIAS,
-                selected_bucket_id=SELECTED_BUCKET_ID,
+                fallback_bucket_id=SELECTED_BUCKET_ID,
             )
 
             submission_store = SubmissionStore(config=config)
@@ -151,7 +151,7 @@ def ingest_fixture() -> Generator[IngestFixture, None, None]:
                 map_files_fields=["study_files"],
                 submission_store_dir=Path(submission_store_dir),
                 selected_storage_alias=SELECTED_STORAGE_ALIAS,
-                selected_bucket_id=SELECTED_BUCKET_ID,
+                fallback_bucket_id=SELECTED_BUCKET_ID,
             )
 
             submission_store = SubmissionStore(config=config)

--- a/tests/fixtures/ingest.py
+++ b/tests/fixtures/ingest.py
@@ -50,7 +50,7 @@ EXAMPLE_SUBMISSION = Submission(
 )
 
 SELECTED_STORAGE_ALIAS = "test"
-SELECTED_BUCKET_ID = "selected-test-bucket"
+FALLBACK_BUCKET_ID = "fallback-test-bucket"
 
 
 @dataclass
@@ -100,7 +100,7 @@ def legacy_ingest_fixture() -> Generator[IngestFixture, None, None]:
                 map_files_fields=["study_files"],
                 submission_store_dir=Path(submission_store_dir),
                 selected_storage_alias=SELECTED_STORAGE_ALIAS,
-                fallback_bucket_id=SELECTED_BUCKET_ID,
+                fallback_bucket_id=FALLBACK_BUCKET_ID,
             )
 
             submission_store = SubmissionStore(config=config)
@@ -151,7 +151,7 @@ def ingest_fixture() -> Generator[IngestFixture, None, None]:
                 map_files_fields=["study_files"],
                 submission_store_dir=Path(submission_store_dir),
                 selected_storage_alias=SELECTED_STORAGE_ALIAS,
-                fallback_bucket_id=SELECTED_BUCKET_ID,
+                fallback_bucket_id=FALLBACK_BUCKET_ID,
             )
 
             submission_store = SubmissionStore(config=config)

--- a/tests/test_file_ingest.py
+++ b/tests/test_file_ingest.py
@@ -42,7 +42,7 @@ async def test_alias_to_accession(legacy_ingest_fixture: IngestFixture):  # noqa
     metadata = models.LegacyOutputMetadata.load(
         input_path=legacy_ingest_fixture.file_path,
         selected_alias=legacy_ingest_fixture.config.selected_storage_alias,
-        selected_bucket=legacy_ingest_fixture.config.selected_bucket_id,
+        selected_bucket=legacy_ingest_fixture.config.fallback_bucket_id,
     )
 
     accession = alias_to_accession(
@@ -213,7 +213,7 @@ def test_fallbacks(
     tmp_path,
 ):
     """Simulate loading old metadata files and test for newly populated fields"""
-    bucket_id = ingest_fixture.config.selected_bucket_id
+    bucket_id = ingest_fixture.config.fallback_bucket_id
     storage_alias = ingest_fixture.config.selected_storage_alias
 
     for fixture, metadata_model in zip(

--- a/tests/test_file_ingest.py
+++ b/tests/test_file_ingest.py
@@ -218,7 +218,7 @@ def test_fallbacks(
 
     for fixture, metadata_model in zip(
         (legacy_ingest_fixture, ingest_fixture),
-        (models.LegacyOutputMetadata, models.OutputMetadata),
+        (models.LegacyOutputMetadata, models.OutputMetadata),  # type: ignore[arg-type]
         strict=True,
     ):
         with fixture.file_path.open("r") as source:
@@ -231,7 +231,7 @@ def test_fallbacks(
         with modified_metadata_path.open("w") as target:
             json.dump(data, target)
 
-        metadata = metadata_model.load(
+        metadata = metadata_model.load(  # type: ignore[attr-defined]
             input_path=modified_metadata_path,
             selected_alias=storage_alias,
             selected_bucket=bucket_id,

--- a/tests/test_file_ingest.py
+++ b/tests/test_file_ingest.py
@@ -42,7 +42,7 @@ async def test_alias_to_accession(legacy_ingest_fixture: IngestFixture):  # noqa
     metadata = models.LegacyOutputMetadata.load(
         input_path=legacy_ingest_fixture.file_path,
         selected_alias=legacy_ingest_fixture.config.selected_storage_alias,
-        selected_bucket=legacy_ingest_fixture.config.fallback_bucket_id,
+        fallback_bucket=legacy_ingest_fixture.config.fallback_bucket_id,
     )
 
     accession = alias_to_accession(
@@ -234,7 +234,7 @@ def test_fallbacks(
         metadata = metadata_model.load(  # type: ignore[attr-defined]
             input_path=modified_metadata_path,
             selected_alias=storage_alias,
-            selected_bucket=bucket_id,
+            fallback_bucket=bucket_id,
         )
         assert metadata.bucket_id == bucket_id
         assert metadata.storage_alias == storage_alias

--- a/tests/test_file_ingest.py
+++ b/tests/test_file_ingest.py
@@ -15,6 +15,8 @@
 
 """File ingest tests."""
 
+import json
+
 import pytest
 import yaml
 from ghga_service_commons.utils.simple_token import generate_token
@@ -40,6 +42,7 @@ async def test_alias_to_accession(legacy_ingest_fixture: IngestFixture):  # noqa
     metadata = models.LegacyOutputMetadata.load(
         input_path=legacy_ingest_fixture.file_path,
         selected_alias=legacy_ingest_fixture.config.selected_storage_alias,
+        selected_bucket=legacy_ingest_fixture.config.selected_bucket_id,
     )
 
     accession = alias_to_accession(
@@ -202,3 +205,36 @@ async def test_legacy_main(
         out, _ = capfd.readouterr()
 
         assert "Encountered 1 errors during processing" in out
+
+
+def test_fallbacks(
+    legacy_ingest_fixture: IngestFixture,  # noqa: F811
+    ingest_fixture: IngestFixture,  # noqa: F811
+    tmp_path,
+):
+    """Simulate loading old metadata files and test for newly populated fields"""
+    bucket_id = ingest_fixture.config.selected_bucket_id
+    storage_alias = ingest_fixture.config.selected_storage_alias
+
+    for fixture, metadata_model in zip(
+        (legacy_ingest_fixture, ingest_fixture),
+        (models.LegacyOutputMetadata, models.OutputMetadata),
+        strict=True,
+    ):
+        with fixture.file_path.open("r") as source:
+            data = json.load(source)
+
+        del data["Bucket ID"]
+        del data["Storage alias"]
+
+        modified_metadata_path = tmp_path / "old_metadata.txt"
+        with modified_metadata_path.open("w") as target:
+            json.dump(data, target)
+
+        metadata = metadata_model.load(
+            input_path=modified_metadata_path,
+            selected_alias=storage_alias,
+            selected_bucket=bucket_id,
+        )
+        assert metadata.bucket_id == bucket_id
+        assert metadata.storage_alias == storage_alias


### PR DESCRIPTION
- Added `bucket_id` to output metadata models, which is populated from config by looking at available `object_storages` and the `selected_storage_alias`
- Added `selected_bucket_id` config parameter to `IngestConfig` as fallback to populate `bucket_id` values in old metadata 
- Minor version bump due to new config option
- Added code to populate `bucket_id` fallback during ingest 
- Added logging at some branching points during ingest
- Updated some missing information to readme