### PR TITLE
Use metldata v4 (GSI-1710)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,12 +1,12 @@
 [project]
 name = "ghga_datasteward_kit"
-version = "4.9.0"
+version = "5.0.0"
 description = "GHGA Data Steward Kit - A utils package for GHGA data stewards."
 dependencies = [
     "crypt4gh >=1.6, <2",
     "hexkit[s3] >=5.3",
     "ghga-transpiler >=2.1.2, <3",
-    "metldata~=3.2",
+    "metldata~=4.0",
     "tenacity >=9.0.0, <10",
 ]
 

--- a/lock/requirements-dev.txt
+++ b/lock/requirements-dev.txt
@@ -941,9 +941,9 @@ mdurl==0.1.2 \
     --hash=sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8 \
     --hash=sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba
     # via markdown-it-py
-metldata==3.2.0 \
-    --hash=sha256:b1f79317907e8091ca3866870ee5974e71516b27df89c4aba8c22e10ce83c0f2 \
-    --hash=sha256:d2cec494449fba01ff99a2e4acec16f5310ac5aa071c270114ac95cab10fd565
+metldata==4.0.0 \
+    --hash=sha256:01c50cc236a5327c081fdd94797182fdc4e1d4f96758c177ad2b2c9ca2c2c3c4 \
+    --hash=sha256:a99b6a44f03f1d683a6c31a77c1bbb53b5ca24921f79a13705e20c0e63fd6dcb
     # via ghga-datasteward-kit (pyproject.toml)
 motor==3.7.1 \
     --hash=sha256:27b4d46625c87928f331a6ca9d7c51c2f518ba0e270939d395bc1ddc89d64526 \

--- a/lock/requirements.txt
+++ b/lock/requirements.txt
@@ -932,9 +932,9 @@ mdurl==0.1.2 \
     # via
     #   -c lock/requirements-dev.txt
     #   markdown-it-py
-metldata==3.2.0 \
-    --hash=sha256:b1f79317907e8091ca3866870ee5974e71516b27df89c4aba8c22e10ce83c0f2 \
-    --hash=sha256:d2cec494449fba01ff99a2e4acec16f5310ac5aa071c270114ac95cab10fd565
+metldata==4.0.0 \
+    --hash=sha256:01c50cc236a5327c081fdd94797182fdc4e1d4f96758c177ad2b2c9ca2c2c3c4 \
+    --hash=sha256:a99b6a44f03f1d683a6c31a77c1bbb53b5ca24921f79a13705e20c0e63fd6dcb
     # via
     #   -c lock/requirements-dev.txt
     #   ghga-datasteward-kit (pyproject.toml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,13 +21,13 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_datasteward_kit"
-version = "4.9.0"
+version = "5.0.0"
 description = "GHGA Data Steward Kit - A utils package for GHGA data stewards."
 dependencies = [
     "crypt4gh >=1.6, <2",
     "hexkit[s3] >=5.3",
     "ghga-transpiler >=2.1.2, <3",
-    "metldata~=3.2",
+    "metldata~=4.0",
     "tenacity >=9.0.0, <10",
 ]
 


### PR DESCRIPTION
The newest `metldata` release includes some changes to how events are collected from the file system before calling the metldata load API. This PR grabs that new metldata release, but no other changes should be required. The major version was bumped because the events loaded before vs after the change are not really compatible.